### PR TITLE
fix(package): proper metadata in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,15 @@
   "version": "1.0.3",
   "type": "module",
   "main": "dist/index.js",
-  "exports": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "benchmark": "tsex benchmark",
     "benchmark:watch": "tsex benchmark --watch",


### PR DESCRIPTION
This adjusts the package.json metadata to properly describe the export of the package by adding `module` and properly using `exports` mappings.

I also added a `files` array, because currently the published tarball has _all_ files whereas only `dist` is required (npm will automatically include `license` and `readme.md`)

![-1729078882](https://github.com/user-attachments/assets/c5b66638-7b34-4cbc-a1c1-0600d3d49638)
